### PR TITLE
Undefined variable $count, $slider

### DIFF
--- a/envato-flex-slider.php
+++ b/envato-flex-slider.php
@@ -8,78 +8,76 @@ Version: 0.5
 Author URI: http://www.casabona.org
 */
 
-/*Some Set-up*/
-define('EFS_PATH', get_template_directory_uri() . '/inc/vendors/' . basename( dirname(__FILE__) ) . '/' );
+/* Some Set-up */
+define('EFS_PATH', get_template_directory_uri() . '/inc/vendors/' . basename(dirname(__FILE__)) . '/');
 define('EFS_NAME', "Envato FlexSlider");
-define ("EFS_VERSION", "0.5");
+define("EFS_VERSION", "0.5");
 
-/*Files to Include*/
+/* Files to Include */
 require_once('slider-img-type.php');
 
-function efs_get_slider(){
-	$efs_query = "post_type=slider-image";
-	query_posts($efs_query);
-	
-	global $post_id;
-	
-	if (have_posts()) : 	
-		
-		$slider = '<div class="orbit" role="region" aria-label="Banner Slider" data-orbit data-options="animInFromLeft:fade-in; animInFromRight:fade-in; animOutToLeft:fade-out; animOutToRight:fade-out;">
-					<ul class="orbit-container">';		
-		
-		$count = 0;
-		$x = 1;
-		while (have_posts()) : the_post();
-			$count++;
-		endwhile;
+function efs_get_slider() {
+  $args = array(
+    'post_type' => 'slider-image',
+    'posts_per_page' => -1 // Get all posts
+  );
+  $query = new WP_Query($args);
 
-		while (have_posts()) : the_post();
-			$img = get_the_post_thumbnail($post_id, 'full', array( 'class' => 'orbit-image' ));
-			
-  		$slide_link = slider_link_get_meta_box_data(get_the_ID());
-			$caption = get_the_title();
+  global $post_id;
 
-			if ($x > $count) {
-				$x = 1;
-			}
-			$slider.= $post_id.'<li class="orbit-slide is-active"><div class="orbit-slide-number"><span>'.$x.'</span> of <span>'.$count.'</span></div><a href="'.$slide_link.'">'.$img.'</a><figcaption class="orbit-caption">'.$caption.'</figcaption></li>';
-			$x++;
-		endwhile;
+  if ($query->have_posts()) {
+    $count = $query->post_count;
+    $slider = '<div class="orbit" role="region" aria-label="Banner Slider" data-orbit data-options="animInFromLeft:fade-in; animInFromRight:fade-in; animOutToLeft:fade-out; animOutToRight:fade-out;">
+                <ul class="orbit-container">';
 
-		if($count > 1) {
-			$slider .= '<button class="orbit-previous"><span class="show-for-sr">Previous Slide</span>&#9664;&#xFE0E;</button>
-						<button class="orbit-next"><span class="show-for-sr">Next Slide</span>&#9654;&#xFE0E;</button>';
-		}
-	endif;
-	wp_reset_query();
+    $x = 1;
+    while ($query->have_posts()) {
+      $query->the_post();
+      $img = get_the_post_thumbnail(get_the_ID(), 'full', array('class' => 'orbit-image'));
+      $slide_link = slider_link_get_meta_box_data(get_the_ID());
+      $caption = get_the_title();
 
-	if($count > 1) {
-		$slider .= '</ul>
-		<nav class="orbit-bullets">';
+      $class = ($x == 1) ? 'is-active' : '';
+      $slider .= '<li class="orbit-slide ' . $class . '"><div class="orbit-slide-number"><span>' . $x . '</span> of <span>' . $count . '</span></div><a href="' . $slide_link . '">' . $img . '</a><figcaption class="orbit-caption">' . $caption . '</figcaption></li>';
+      $x++;
+    }
 
-		for ($x=0; $x < $count ; $x++) { 
-			$class = ($x == 0) ? 'is-active' : '' ;
-			$slider .= '<button class="'.$class.'" data-slide="'.$x.'"><span class="show-for-sr">Current Slide</span></button>';
-		}
+    if ($count > 1) {
+      $slider .= '<button class="orbit-previous"><span class="show-for-sr">Previous Slide</span>&#9664;&#xFE0E;</button>
+                  <button class="orbit-next"><span class="show-for-sr">Next Slide</span>&#9654;&#xFE0E;</button>';
+    }
+    
+    $slider .= '</ul>';
+    
+    if ($count > 1) {
+      $slider .= '<nav class="orbit-bullets">';
+      for ($i = 0; $i < $count; $i++) {
+        $class = ($i == 0) ? 'is-active' : '';
+        $slider .= '<button class="' . $class . '" data-slide="' . $i . '"><span class="show-for-sr">Current Slide</span></button>';
+      }
+      $slider .= '</nav>';
+    }
 
-		$slider .= '</div></nav>';
-	} else {
-		$slider .= '</ul></div>';
-	}
+    $slider .= '</div>';
 
-	return $slider;
+    wp_reset_postdata(); // Reset the query data
+
+    return $slider;
+  } else {
+    return;
+  }
 }
 
-/**add the shortcode for the slider- for use in editor**/
-function efs_insert_slider($atts, $content=null) {
-	$slider= efs_get_slider();
-	return $slider;
+/** Add the shortcode for the slider - for use in editor **/
+function efs_insert_slider($atts, $content = null) {
+  $slider = efs_get_slider();
+  return $slider;
 }
 add_shortcode('ef_slider', 'efs_insert_slider');
 
-/**add template tag- for use in themes**/
+/** Add template tag - for use in themes **/
 function efs_slider() {
-	print efs_get_slider();
+  echo efs_get_slider();
 }
 
 ?>


### PR DESCRIPTION
This fiixes these errors:
```
Warning: Undefined variable $count in /var/www/html/wordpress/wp-content/themes/gwt-wordpress/vendors/envato-flex-slider/envato-flex-slider.php on line 56

Warning: Undefined variable $slider in /var/www/html/wordpress/wp-content/themes/gwt-wordpress/vendors/envato-flex-slider/envato-flex-slider.php on line 67
```


The error occurs because :

1.)  The variable `$count` is being used outside the context where it was initialized. Specifically, the issue arises from the usage of `$count` after the```while (have_posts())``` loop, but before the query has been fully reset.

2.) Usage of `query_posts()` directly, which modifies the main query and can cause unexpected issues. Instead I used `WP_Query` for custom queries.
